### PR TITLE
Implement RESTful /answers and /feedback endpoints

### DIFF
--- a/app/api/handlers/telegram.py
+++ b/app/api/handlers/telegram.py
@@ -80,6 +80,7 @@ async def ask_receive(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
             "⚠️ Sorry, something went wrong. Please try again later."
         )
     else:
+
         await update.message.reply_text(answer)
     # End conversation
     return ConversationHandler.END

--- a/app/api/models/chat_models.py
+++ b/app/api/models/chat_models.py
@@ -1,0 +1,20 @@
+import uuid
+from typing import Optional, Literal
+from pydantic import BaseModel, Field
+
+# --- Pydantic Модели ---
+
+class AskRequest(BaseModel):
+    """Модель запроса для получения ответа."""
+    query: str = Field(..., description="Текст вопроса от пользователя", min_length=1)
+
+class AskResponse(BaseModel):
+    """Модель ответа со сгенерированным текстом и ID ответа."""
+    answer_id: uuid.UUID = Field(..., description="Уникальный идентификатор ответа для обратной связи")
+    answer: Optional[str] = Field(None, description="Сгенерированный ответ бота или null, если ответ не найден")
+
+class FeedbackRequest(BaseModel):
+    """Модель для отправки обратной связи на ответ бота."""
+    feedback_reaction: Literal["positive", "negative", "neutral"] = Field(..., description="Оценка ответа")
+    comment: Optional[str] = Field(None, description="Опциональный текстовый комментарий", max_length=1000)
+

--- a/app/api/router/assistant.py
+++ b/app/api/router/assistant.py
@@ -1,0 +1,72 @@
+import logging
+import uuid  # Используем для генерации уникальных ID
+from fastapi import APIRouter, HTTPException, status, Response
+from app.api.models.chat_models import AskResponse, AskRequest, FeedbackRequest
+from app.clients.ya_gpt import answer_from_knowledge_base
+
+
+router = APIRouter(
+    prefix="/v1", # Префикс для всех routes в этом файле
+    tags=["Chat Assistant"] # Группировка в документации Swagger/OpenAPI
+)
+
+# --- Endpoints ---
+@router.post(
+    "/answers",
+    response_model=AskResponse,
+    status_code=status.HTTP_201_CREATED, # Используем 201 для создания ресурса "ответ"
+    summary="Запросить ответ у ассистента",
+    description="Принимает вопрос пользователя, генерирует ответ с помощью RAG и возвращает ответ вместе с уникальным ID."
+)
+async def ask_assistant(request_data: AskRequest):
+    """
+    Обрабатывает вопрос пользователя и возвращает ответ.
+    Генерирует уникальный `answer_id` для каждого ответа.
+    """
+    question = request_data.query
+    generated_answer_id = uuid.uuid4() # Генерируем ID для этого конкретного ответа
+
+    try:
+        logging.info(f"Processing question for answer_id '{generated_answer_id}': '{question}'")
+        answer_text = await answer_from_knowledge_base(question)
+
+        if answer_text:
+            logging.info(f"Answer found for answer_id '{generated_answer_id}'.")
+            logging.debug(f"Answer text for answer_id '{generated_answer_id}': {answer_text}")
+        else:
+            logging.warning(f"No answer found in knowledge base for answer_id '{generated_answer_id}")
+        return AskResponse(answer_id=generated_answer_id, answer=answer_text)
+
+    except Exception as e:
+        logging.error(f"Error processing question for potential answer_id '{generated_answer_id}': {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An internal error occurred while processing your request."
+        )
+
+
+@router.post(
+    "/answers/{answer_id}/feedback",
+    status_code=status.HTTP_204_NO_CONTENT, # Устанавливаем статус по умолчанию
+    summary="Отправить обратную связь на ответ",
+    description="Позволяет пользователю отправить реакцию (positive/negative/neutral) и опциональный комментарий на конкретный ответ, идентифицированный по answer_id."
+)
+async def submit_feedback(answer_id: uuid.UUID, feedback_data: FeedbackRequest):
+    """
+    Принимает обратную связь на конкретный ответ.
+    Логирует фидбек для дальнейшего анализа.
+    """
+    try:
+        logging.info(
+            f"Feedback received for answer_id '{answer_id}': "
+            f"Reaction='{feedback_data.feedback_reaction}', "
+            f"Comment='{feedback_data.comment if feedback_data.comment else 'N/A'}'. "
+        )
+        return Response(status_code=status.HTTP_202_ACCEPTED, content="Feedback received successfully.")
+
+    except Exception as e:
+        logging.error(f"Error processing feedback for answer_id '{answer_id}': {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An internal error occurred while processing your feedback."
+        )


### PR DESCRIPTION
Всем привет!

Завершила реализацию базовых REST API эндпоинтов для нашего ассистента (assistant.py)  в ветке tokeon_REST_API:
- POST /v1/answers: для получения ответа и его answer_id.
- POST /v1/answers/{answer_id}/feedback: для отправки фидбека на ответ.

Эндпоинты спроектированы с учетом REST-принципов и требования анонимности пользователей (используется answer_id для связи фидбека). Pydantic-модели вынесены в app/api/models/chat_models.py.

Ветку запушила. Готова к дальнейшим шагам/ревью.